### PR TITLE
Fix/Update functional tests

### DIFF
--- a/tests/functional/boardrules_controller_test.php
+++ b/tests/functional/boardrules_controller_test.php
@@ -107,7 +107,7 @@ class phpbb_functional_boardrules_controller_test extends \extension_functional_
 	*
 	* @access public
 	*/
-	public function test_boardrules_page()
+	public function test_boardrules_header_link()
 	{
 		$this->logout();
 		$crawler = self::request('GET', 'index.php');


### PR DESCRIPTION
The board rules are installed "tuned off" and now that we merged the changes to hide them when off, we need to turn them on in order to successfully perform functional tests of the main controller.
