### PR TITLE
Use native h2 styling for Board rules page titles

### DIFF
--- a/styles/prosilver/theme/boardrules_controller.css
+++ b/styles/prosilver/theme/boardrules_controller.css
@@ -22,14 +22,6 @@
 
 .content ol ol{ font-size: 1em; }
 
-/* rules header */
-.boardrules-header {
-	color: #4f84ad;
-	font-size: 2.8em;
-	font-weight: 900;
-	font-family: Helvetica, Arial, sans-serif;
-}
-
 /* rules */
 #rules { padding-right: 50px; }
 #rules li { margin-bottom: 20px; }

--- a/styles/subsilver2/theme/boardrules_controller.css
+++ b/styles/subsilver2/theme/boardrules_controller.css
@@ -30,7 +30,6 @@
 
 /* rules header */
 .boardrules-header {
-	color: #005784;
 	font-size: 2.8em;
 }
 


### PR DESCRIPTION
Again, this is to make the styling more compatible with 3rd party styles by relying on the style's CSS instead of creating our own, and more consistent with all of phpBB's other pages

![screen shot 2014-07-06 at 7 52 10 pm](https://cloud.githubusercontent.com/assets/303711/3490989/0fcd8bb0-0583-11e4-9561-6d5bd2050a8e.png)
