### PR TITLE
More strict rules on anchor character input

### DIFF
--- a/entity/rule.php
+++ b/entity/rule.php
@@ -476,8 +476,8 @@ class rule implements rule_interface
 		// Enforce a string
 		$anchor = (string) $anchor;
 
-		// Anchor should start with a letter to be a valid HTML id attribute
-		if (!preg_match('/^[a-z]+[a-z0-9_-]*$/i', $anchor) && $anchor != '')
+		// Anchor should not contain any special characters
+		if (!preg_match('/^[^!"#$%&*\'()+,.\/\\\\:;<=>?@\[\]^`{|}~ ]*$/i', $anchor) && $anchor != '')
 		{
 			throw new \phpbb\boardrules\exception\unexpected_value(array('anchor', 'ILLEGAL_CHARACTERS'));
 		}

--- a/styles/all/template/boardrules_controller.js
+++ b/styles/all/template/boardrules_controller.js
@@ -13,7 +13,7 @@
 
 		// Function to apply highlight class to an element identifier
 		function highlight(id) {
-			$("#" + id).addClass("highlight");
+			$("#" + decodeURIComponent(id)).addClass("highlight");
 		}
 
 	});

--- a/tests/entity/rule_entity_anchor_test.php
+++ b/tests/entity/rule_entity_anchor_test.php
@@ -26,6 +26,8 @@ class rule_entity_anchor_test extends rule_entity_base
 		return array(
 			// sent to set_anchor(), expected from get_anchor()
 			array('foo', 'foo'),
+			array('foø-bar', 'foø-bar'),
+			array('foó-bar', 'foó-bar'),
 			array('', ''),
 			array(null, ''),
 
@@ -67,16 +69,24 @@ class rule_entity_anchor_test extends rule_entity_base
 	public function anchor_fails_test_data()
 	{
 		return array(
-			// Starts with a non-letter
-			array('1foo'),
+			// Starts with illegal characters
 			array('#foo'),
 			array(' foo'),
 
 			// Contains illegal characters
 			array('foo bar'),
 			array('foo?bar'),
-			array('foø-bar'),
-			array('foó-bar'),
+			array('foo#bar'),
+			array('foo&bar'),
+			array('foo$bar'),
+			array('foo/bar'),
+			array('foo@bar'),
+			array('foo=bar'),
+			array('foo+bar'),
+			array('foo^bar'),
+			array('foo*bar'),
+			array('foo\'bar'),
+			array('foo\\bar'),
 
 			// Exceeds character maximum length
 			array(


### PR DESCRIPTION
only alpha numeric chars and dash and underscore can be used in anchor names, and that they don't start with a number (because anchors are used as HTML ID attributes).
