### PR TITLE
Rename service. text_reparser should come first.

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -78,7 +78,7 @@ services:
         tags:
             - { name: notification.type }
 
-    phpbb.boardrules.text_reparser.rule_text:
+    text_reparser.phpbb_boardrules_rule_text:
         class: phpbb\boardrules\textreparser\plugins\rule_text
         arguments:
             - '@dbal.conn'


### PR DESCRIPTION
Doing this because "text_reparser" is removed from the front of these service names when used, for example in the CLI. So instead of displaying this service to users as: 

```
phpbb.boardrules.text_reparser.rule_text
``` 

it will instead display more inline with the other reparser services and be much more manageable for users to grasp, as: 

```
phpbb_boardrules_rule_text
``` 