### PR TITLE
Convert language from using ID nums to ISO names

### DIFF
--- a/acp/boardrules_module.php
+++ b/acp/boardrules_module.php
@@ -34,7 +34,7 @@ class boardrules_module
 
 		// Requests
 		$action = $request->variable('action', '');
-		$language = $request->variable('language', 0);
+		$language = $request->variable('language', '');
 		$parent_id = $request->variable('parent_id', 0);
 		$rule_id = $request->variable('rule_id', 0);
 

--- a/acp/boardrules_module.php
+++ b/acp/boardrules_module.php
@@ -26,11 +26,11 @@ class boardrules_module
 		/** @var \phpbb\request\request $request */
 		$request = $phpbb_container->get('request');
 
+		/** @var \phpbb\boardrules\controller\admin_controller $admin_controller */
+		$admin_controller = $phpbb_container->get('phpbb.boardrules.admin.controller');
+
 		// Add the board rules ACP lang file
 		$lang->add_lang('boardrules_acp', 'phpbb/boardrules');
-
-		// Get an instance of the admin controller
-		$admin_controller = $phpbb_container->get('phpbb.boardrules.admin.controller');
 
 		// Requests
 		$action = $request->variable('action', '');

--- a/adm/style/boardrules_manage.html
+++ b/adm/style/boardrules_manage.html
@@ -111,7 +111,7 @@
 					<dd>
 						<select name="language" id="language">
 							<!-- BEGIN options -->
-								<option value="{options.LANG_ID}"<!-- IF options.S_LANG_DEFAULT --> selected="selected"<!-- ENDIF -->>{options.LANG_LOCAL_NAME}</option>
+								<option value="{options.LANG_ISO}"<!-- IF options.S_LANG_DEFAULT --> selected="selected"<!-- ENDIF -->>{options.LANG_LOCAL_NAME}</option>
 							<!-- END options -->
 						</select>
 						<input type="submit" value="{L_GO}" class="button2">

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"type": "phpbb-extension",
 	"description": "An extension which allows you to create a set of rules for your phpBB forum",
 	"homepage": "https://www.phpbb.com",
-	"version": "2.0.1-dev",
+	"version": "2.1.0-dev",
 	"keywords": ["phpbb", "extension", "rules"],
 	"license": "GPL-2.0",
 	"authors": [

--- a/controller/admin_controller.php
+++ b/controller/admin_controller.php
@@ -181,7 +181,7 @@ class admin_controller implements admin_interface
 	public function display_language_selection()
 	{
 		// Check if there are any available languages
-		$sql = 'SELECT lang_id, lang_iso, lang_local_name
+		$sql = 'SELECT lang_iso, lang_local_name
 			FROM ' . LANG_TABLE . '
 			ORDER BY lang_english_name';
 		$result = $this->db->sql_query($sql);
@@ -196,7 +196,7 @@ class admin_controller implements admin_interface
 				$this->template->assign_block_vars('options', array(
 					'S_LANG_DEFAULT'	=> $row['lang_iso'] == $this->config['default_lang'],
 
-					'LANG_ID'			=> $row['lang_id'],
+					'LANG_ISO'			=> $row['lang_iso'],
 					'LANG_LOCAL_NAME'	=> $row['lang_local_name'],
 				));
 			}
@@ -208,20 +208,20 @@ class admin_controller implements admin_interface
 		{
 			// If there is only one available language its index is 0
 			// and that language is the default board language.
-			// We do not need any loops here to get its id.
-			$this->display_rules($rows[0]['lang_id']);
+			// We do not need any loops here to get its iso code.
+			$this->display_rules($rows[0]['lang_iso']);
 		}
 	}
 
 	/**
 	* Display the rules
 	*
-	* @param int $language Language selection identifier; default: 0
+	* @param string $language Language selection iso
 	* @param int $parent_id Category to display rules from; default: 0
 	* @return void
 	* @access public
 	*/
-	public function display_rules($language = 0, $parent_id = 0)
+	public function display_rules($language, $parent_id = 0)
 	{
 		// Grab all the rules in the current user's language
 		$entities = $this->rule_operator->get_rules($language, $parent_id);
@@ -282,12 +282,12 @@ class admin_controller implements admin_interface
 	/**
 	* Add a rule
 	*
-	* @param int $language Language selection identifier; default: 0
+	* @param string $language Language selection iso
 	* @param int $parent_id Category to display rules from; default: 0
 	* @return void
 	* @access public
 	*/
-	public function add_rule($language = 0, $parent_id = 0)
+	public function add_rule($language, $parent_id = 0)
 	{
 		// Add form key
 		add_form_key('add_edit_rule');

--- a/controller/admin_interface.php
+++ b/controller/admin_interface.php
@@ -39,22 +39,22 @@ interface admin_interface
 	/**
 	* Display the rules
 	*
-	* @param int $language Language selection identifier; default: 0
+	* @param string $language Language selection iso
 	* @param int $parent_id Category to display rules from; default: 0
 	* @return void
 	* @access public
 	*/
-	public function display_rules($language = 0, $parent_id = 0);
+	public function display_rules($language, $parent_id = 0);
 
 	/**
 	* Add a rule
 	*
-	* @param int $language Language selection identifier; default: 0
+	* @param string $language Language selection iso
 	* @param int $parent_id Category to display rules from; default: 0
 	* @return void
 	* @access public
 	*/
-	public function add_rule($language = 0, $parent_id = 0);
+	public function add_rule($language, $parent_id = 0);
 
 	/**
 	* Edit a rule

--- a/controller/main_controller.php
+++ b/controller/main_controller.php
@@ -87,7 +87,7 @@ class main_controller implements main_interface
 		$rule_counter = 'a'; // Alpha counter used for rules
 
 		// Grab all the rules in the current user's language
-		$entities = $this->rule_operator->get_rules($this->user->get_iso_lang_id());
+		$entities = $this->rule_operator->get_rules($this->lang->get_used_language());
 
 		/* @var $entity \phpbb\boardrules\entity\rule */
 		foreach ($entities as $entity)

--- a/entity/rule.php
+++ b/entity/rule.php
@@ -535,11 +535,28 @@ class rule implements rule_interface
 	 * @param string $language language iso
 	 * @return rule_interface $this object for chaining calls; load()->set()->save()
 	 * @access public
+	 * @throws \phpbb\boardrules\exception\unexpected_value
 	 */
 	public function set_language($language)
 	{
 		if (!isset($this->data['rule_language']))
 		{
+			// Validate the requested language ISO is installed
+			if ($language !== '')
+			{
+				$sql = 'SELECT lang_id
+					FROM ' . LANG_TABLE . "
+					WHERE lang_iso = '" . $this->db->sql_escape($language) . "'";
+				$result = $this->db->sql_query($sql);
+				$lang_id = $this->db->sql_fetchfield('lang_id');
+				$this->db->sql_freeresult($result);
+
+				if (!$lang_id)
+				{
+					throw new \phpbb\boardrules\exception\unexpected_value(array('rule_language', 'WRONG_DATA_LANG', 'UNEXPECTED_VALUE'));
+				}
+			}
+
 			$this->data['rule_language'] = $language;
 		}
 

--- a/entity/rule.php
+++ b/entity/rule.php
@@ -526,7 +526,7 @@ class rule implements rule_interface
 	*/
 	public function get_language()
 	{
-		return isset($this->data['rule_language']) ? $this->data['rule_language'] : 'en';
+		return isset($this->data['rule_language']) ? $this->data['rule_language'] : '';
 	}
 
 	/**

--- a/entity/rule.php
+++ b/entity/rule.php
@@ -105,7 +105,7 @@ class rule implements rule_interface
 		$fields = array(
 			// column							=> data type (see settype())
 			'rule_id'							=> 'integer',
-			'rule_language'						=> 'integer',
+			'rule_language'						=> 'string',
 			'rule_left_id'						=> 'integer',
 			'rule_right_id'						=> 'integer',
 			'rule_parent_id'					=> 'integer',
@@ -149,7 +149,6 @@ class rule implements rule_interface
 		// Some fields must be unsigned (>= 0)
 		$validate_unsigned = array(
 			'rule_id',
-			'rule_language',
 			'rule_left_id',
 			'rule_right_id',
 			'rule_parent_id',
@@ -173,12 +172,12 @@ class rule implements rule_interface
 	*
 	* Will throw an exception if the rule was already inserted (call save() instead)
 	*
-	* @param int $language The language identifier
+	* @param string $language The language iso
 	* @return rule_interface $this object for chaining calls; load()->set()->save()
 	* @access public
 	* @throws \phpbb\boardrules\exception\out_of_bounds
 	*/
-	public function insert($language = 0)
+	public function insert($language)
 	{
 		if (!empty($this->data['rule_id']))
 		{
@@ -502,7 +501,7 @@ class rule implements rule_interface
 				FROM ' . $this->boardrules_table . "
 				WHERE rule_anchor = '" . $this->db->sql_escape($anchor) . "'
 					AND rule_id <> " . $this->get_id() .
-					($this->get_language() ? ' AND rule_language = ' . $this->get_language() : '');
+					($this->get_language() ? " AND rule_language = '" . $this->get_language() . "'" : '');
 			$result = $this->db->sql_query_limit($sql, 1);
 			$row = $this->db->sql_fetchrow($result);
 			$this->db->sql_freeresult($result);
@@ -520,20 +519,20 @@ class rule implements rule_interface
 	}
 
 	/**
-	* Get the language identifier
+	* Get the language iso
 	*
-	* @return int language identifier
+	* @return string language iso
 	* @access public
 	*/
 	public function get_language()
 	{
-		return isset($this->data['rule_language']) ? (int) $this->data['rule_language'] : 0;
+		return isset($this->data['rule_language']) ? $this->data['rule_language'] : 'en';
 	}
 
 	/**
-	 * Set the language identifier
+	 * Set the language iso
 	 *
-	 * @param int $language language identifier
+	 * @param string $language language iso
 	 * @return rule_interface $this object for chaining calls; load()->set()->save()
 	 * @access public
 	 */
@@ -541,7 +540,7 @@ class rule implements rule_interface
 	{
 		if (!isset($this->data['rule_language']))
 		{
-			$this->data['rule_language'] = (int) $language;
+			$this->data['rule_language'] = $language;
 		}
 
 		return $this;

--- a/entity/rule.php
+++ b/entity/rule.php
@@ -152,6 +152,7 @@ class rule implements rule_interface
 			'rule_language',
 			'rule_left_id',
 			'rule_right_id',
+			'rule_parent_id',
 			'rule_message_bbcode_options',
 		);
 

--- a/entity/rule_interface.php
+++ b/entity/rule_interface.php
@@ -46,12 +46,12 @@ interface rule_interface
 	*
 	* Will throw an exception if the rule was already inserted (call save() instead)
 	*
-	* @param int $language The language identifier
+	* @param string $language The language iso
 	* @return rule_interface $this object for chaining calls; load()->set()->save()
 	* @access public
 	* @throws \phpbb\boardrules\exception\out_of_bounds
 	*/
-	public function insert($language = 0);
+	public function insert($language);
 
 	/**
 	* Save the current settings to the database
@@ -208,17 +208,17 @@ interface rule_interface
 	public function set_anchor($anchor);
 
 	/**
-	* Get the language identifier
+	* Get the language iso
 	*
-	* @return int language identifier
+	* @return string language iso
 	* @access public
 	*/
 	public function get_language();
 
 	/**
-	 * Set the language identifier
+	 * Set the language iso
 	 *
-	 * @param int $language language identifier
+	 * @param string $language language iso
 	 * @return rule_interface $this object for chaining calls; load()->set()->save()
 	 * @access public
 	 */

--- a/language/ar/exceptions.php
+++ b/language/ar/exceptions.php
@@ -56,4 +56,7 @@ $lang = array_merge($lang, array(
 	'EXCEPTION_NOT_UNIQUE'			=> 'البيانات المُدخلة موجودة مُسبقاً.',
 	'EXCEPTION_UNEXPECTED_VALUE'	=> 'هناك خطأ في البيانات المُدخلة في الحقل `%1$s`. السبب : %2$s',
 	'EXCEPTION_ILLEGAL_CHARACTERS'	=> 'البيانات التي أدخلتها تحتوي على حروف غير مقبولة.',
+
+	// Translators: do not change this
+	'EXCEPTION_WRONG_DATA_LANG'		=> $lang['WRONG_DATA_LANG'],
 ));

--- a/language/bg/exceptions.php
+++ b/language/bg/exceptions.php
@@ -55,4 +55,7 @@ $lang = array_merge($lang, array(
 	'EXCEPTION_NOT_UNIQUE'			=> 'Въведеното не съответства.',
 	'EXCEPTION_UNEXPECTED_VALUE'	=> 'Полето `%1$s` получава неочаквани данни. Причина: %2$s',
 	'EXCEPTION_ILLEGAL_CHARACTERS'	=> 'Въведенот съдържа непозволени знаци.',
+
+	// Translators: do not change this
+	'EXCEPTION_WRONG_DATA_LANG'		=> $lang['WRONG_DATA_LANG'],
 ));

--- a/language/cs/exceptions.php
+++ b/language/cs/exceptions.php
@@ -55,4 +55,7 @@ $lang = array_merge($lang, array(
 	'EXCEPTION_NOT_UNIQUE'			=> 'Vstup nebyl unikátní.',
 	'EXCEPTION_UNEXPECTED_VALUE'	=> 'Pole `%1$s` obdrželo neočekávaná data. Důvod: %2$s',
 	'EXCEPTION_ILLEGAL_CHARACTERS'	=> 'Vstup obsahuje neplatné znaky.',
+
+	// Translators: do not change this
+	'EXCEPTION_WRONG_DATA_LANG'		=> $lang['WRONG_DATA_LANG'],
 ));

--- a/language/de/exceptions.php
+++ b/language/de/exceptions.php
@@ -55,4 +55,7 @@ $lang = array_merge($lang, array(
 	'EXCEPTION_NOT_UNIQUE'			=> 'Uneindeutige Eingabe. (Bezeichnung bereits vergeben)',
 	'EXCEPTION_UNEXPECTED_VALUE'	=> 'Unerwartete Zeichen in Feld `%1$s`. Grund: %2$s',
 	'EXCEPTION_ILLEGAL_CHARACTERS'	=> 'Eingabe enthält für dieses Feld nicht zulässige Zeichen.',
+
+	// Translators: do not change this
+	'EXCEPTION_WRONG_DATA_LANG'		=> $lang['WRONG_DATA_LANG'],
 ));

--- a/language/de_x_sie/exceptions.php
+++ b/language/de_x_sie/exceptions.php
@@ -56,4 +56,7 @@ $lang = array_merge($lang, array(
 	'EXCEPTION_NOT_UNIQUE'			=> 'Uneindeutige Eingabe (Bezeichnung bereits vergeben).',
 	'EXCEPTION_UNEXPECTED_VALUE'	=> 'Unerwartete Zeichen in Feld `%1$s`. Grund: %2$s',
 	'EXCEPTION_ILLEGAL_CHARACTERS'	=> 'Eingabe enthält für dieses Feld nicht zulässige Zeichen.',
+
+	// Translators: do not change this
+	'EXCEPTION_WRONG_DATA_LANG'		=> $lang['WRONG_DATA_LANG'],
 ));

--- a/language/el/exceptions.php
+++ b/language/el/exceptions.php
@@ -56,4 +56,7 @@ $lang = array_merge($lang, array(
 	'EXCEPTION_NOT_UNIQUE'			=> 'Η εισαχθείσα τιμή δεν ήταν μοναδική.',
 	'EXCEPTION_UNEXPECTED_VALUE'	=> 'Το πεδίο "%1$s" δέχτηκε μη αναμενόμενα δεδομένα. Λόγος: %2$s',
 	'EXCEPTION_ILLEGAL_CHARACTERS'	=> 'Η εισαχθείσα τιμή περιείχε μη επιτρεπτούς χαρακτήρες.',
+
+	// Translators: do not change this
+	'EXCEPTION_WRONG_DATA_LANG'		=> $lang['WRONG_DATA_LANG'],
 ));

--- a/language/en/exceptions.php
+++ b/language/en/exceptions.php
@@ -55,4 +55,7 @@ $lang = array_merge($lang, array(
 	'EXCEPTION_NOT_UNIQUE'			=> 'The input was not unique.',
 	'EXCEPTION_UNEXPECTED_VALUE'	=> 'The field `%1$s` received unexpected data. Reason: %2$s',
 	'EXCEPTION_ILLEGAL_CHARACTERS'	=> 'The input contained illegal characters.',
+
+	// Translators: do not change this
+	'EXCEPTION_WRONG_DATA_LANG'		=> $lang['WRONG_DATA_LANG'],
 ));

--- a/language/es/exceptions.php
+++ b/language/es/exceptions.php
@@ -56,4 +56,7 @@ $lang = array_merge($lang, array(
 	'EXCEPTION_NOT_UNIQUE'			=> 'La entrada no es única.',
 	'EXCEPTION_UNEXPECTED_VALUE'	=> 'El campo `%1$s` ha recibido datos inesperados. Razón: %2$s',
 	'EXCEPTION_ILLEGAL_CHARACTERS'	=> 'La entrada contiene caracteres no válidos.',
+
+	// Translators: do not change this
+	'EXCEPTION_WRONG_DATA_LANG'		=> $lang['WRONG_DATA_LANG'],
 ));

--- a/language/et/exceptions.php
+++ b/language/et/exceptions.php
@@ -56,4 +56,7 @@ $lang = array_merge($lang, array(
 	'EXCEPTION_NOT_UNIQUE'			=> 'Sisend ei olnud unikaalne.',
 	'EXCEPTION_UNEXPECTED_VALUE'	=> 'Väli `%1$s` sai ootamatud andmed. Põhjus: %2$s',
 	'EXCEPTION_ILLEGAL_CHARACTERS'	=> 'Sisend sisaldab keelatuid sümboleid.',
+
+	// Translators: do not change this
+	'EXCEPTION_WRONG_DATA_LANG'		=> $lang['WRONG_DATA_LANG'],
 ));

--- a/language/fr/exceptions.php
+++ b/language/fr/exceptions.php
@@ -56,4 +56,7 @@ $lang = array_merge($lang, array(
 	'EXCEPTION_NOT_UNIQUE'			=> 'La donnée n’était pas unique.',
 	'EXCEPTION_UNEXPECTED_VALUE'	=> 'Le champ `%1$s` a reçu une donnée inattendue. Motif : %2$s',
 	'EXCEPTION_ILLEGAL_CHARACTERS'	=> 'La donnée contenait des caractères interdits.',
+
+	// Translators: do not change this
+	'EXCEPTION_WRONG_DATA_LANG'		=> $lang['WRONG_DATA_LANG'],
 ));

--- a/language/he/exceptions.php
+++ b/language/he/exceptions.php
@@ -55,4 +55,7 @@ $lang = array_merge($lang, array(
 	'EXCEPTION_NOT_UNIQUE'			=> 'התוכן לא היה ייחודי.',
 	'EXCEPTION_UNEXPECTED_VALUE'	=> 'השדה `%1$s` קיבל מידע לא-צפוי. סיבה: %2$s',
 	'EXCEPTION_ILLEGAL_CHARACTERS'	=> 'התוכן הכיל תווים לא חוקיים.',
+
+	// Translators: do not change this
+	'EXCEPTION_WRONG_DATA_LANG'		=> $lang['WRONG_DATA_LANG'],
 ));

--- a/language/hr/exceptions.php
+++ b/language/hr/exceptions.php
@@ -56,4 +56,7 @@ $lang = array_merge($lang, array(
 	'EXCEPTION_NOT_UNIQUE'			=> 'Upis nije jedinstven.',
 	'EXCEPTION_UNEXPECTED_VALUE'	=> 'U polje `%1$s` su upisani neočekivani podatci.<br />Razlog: %2$s.',
 	'EXCEPTION_ILLEGAL_CHARACTERS'	=> 'Upis sadrži nedopuštene znakove.',
+
+	// Translators: do not change this
+	'EXCEPTION_WRONG_DATA_LANG'		=> $lang['WRONG_DATA_LANG'],
 ));

--- a/language/it/exceptions.php
+++ b/language/it/exceptions.php
@@ -56,4 +56,7 @@ $lang = array_merge($lang, array(
 	'EXCEPTION_NOT_UNIQUE'			=> 'La voce non era unica.',
 	'EXCEPTION_UNEXPECTED_VALUE'	=> 'Il campo `%1$s` ha ricevuto dati inaspet. Motivo: %2$s',
 	'EXCEPTION_ILLEGAL_CHARACTERS'	=> 'La voce contiene caratteri non validi.',
+
+	// Translators: do not change this
+	'EXCEPTION_WRONG_DATA_LANG'		=> $lang['WRONG_DATA_LANG'],
 ));

--- a/language/nb/exceptions.php
+++ b/language/nb/exceptions.php
@@ -56,4 +56,7 @@ $lang = array_merge($lang, array(
 	'EXCEPTION_NOT_UNIQUE'			=> 'Inndata var ikke unike.',
 	'EXCEPTION_UNEXPECTED_VALUE'	=> 'Uventede data mottatt i feltet `%1$s`. Årsak: %2$s',
 	'EXCEPTION_ILLEGAL_CHARACTERS'	=> 'Inndata inneholdt tegn som ikke er tillatt.',
+
+	// Translators: do not change this
+	'EXCEPTION_WRONG_DATA_LANG'		=> $lang['WRONG_DATA_LANG'],
 ));

--- a/language/nl/exceptions.php
+++ b/language/nl/exceptions.php
@@ -56,4 +56,7 @@ $lang = array_merge($lang, array(
 	'EXCEPTION_NOT_UNIQUE'			=> 'De invoer is niet uniek.',
 	'EXCEPTION_UNEXPECTED_VALUE'	=> 'Het veld `%1$s` ontvangt onverwachte data. Reden: %2$s',
 	'EXCEPTION_ILLEGAL_CHARACTERS'	=> 'De invoer bevat ongeldige tekens.',
+
+	// Translators: do not change this
+	'EXCEPTION_WRONG_DATA_LANG'		=> $lang['WRONG_DATA_LANG'],
 ));

--- a/language/pl/exceptions.php
+++ b/language/pl/exceptions.php
@@ -56,4 +56,7 @@ $lang = array_merge($lang, array(
 	'EXCEPTION_NOT_UNIQUE'			=> 'Wprowadzone dane nie były wyjątkowe.',
 	'EXCEPTION_UNEXPECTED_VALUE'	=> 'Pole `%1$s` odebrało nieoczekiwane dane. Powód: %2$s',
 	'EXCEPTION_ILLEGAL_CHARACTERS'	=> 'Wprowadzone dane zawierały niedozwolone znaki.',
+
+	// Translators: do not change this
+	'EXCEPTION_WRONG_DATA_LANG'		=> $lang['WRONG_DATA_LANG'],
 ));

--- a/language/pt/exceptions.php
+++ b/language/pt/exceptions.php
@@ -56,4 +56,7 @@ $lang = array_merge($lang, array(
 	'EXCEPTION_NOT_UNIQUE'			=> 'A entrada não é única.',
 	'EXCEPTION_UNEXPECTED_VALUE'	=> 'O campo `%1$s` recebeu dados não previstos. Razão: %2$s',
 	'EXCEPTION_ILLEGAL_CHARACTERS'	=> 'A entrada tem caracteres inválidos.',
+
+	// Translators: do not change this
+	'EXCEPTION_WRONG_DATA_LANG'		=> $lang['WRONG_DATA_LANG'],
 ));

--- a/language/pt_br/exceptions.php
+++ b/language/pt_br/exceptions.php
@@ -56,4 +56,7 @@ $lang = array_merge($lang, array(
 	'EXCEPTION_NOT_UNIQUE'			=> 'A entrada não é única.',
 	'EXCEPTION_UNEXPECTED_VALUE'	=> 'O campo `%1$s` recebeu dados não previstos. Razão: %2$s',
 	'EXCEPTION_ILLEGAL_CHARACTERS'	=> 'A entrada tem caracteres inválidos.',
+
+	// Translators: do not change this
+	'EXCEPTION_WRONG_DATA_LANG'		=> $lang['WRONG_DATA_LANG'],
 ));

--- a/language/ro/exceptions.php
+++ b/language/ro/exceptions.php
@@ -55,4 +55,7 @@ $lang = array_merge($lang, array(
 	'EXCEPTION_NOT_UNIQUE'			=> 'Campul nu este unic.',
 	'EXCEPTION_UNEXPECTED_VALUE'	=> 'Campul `%1$s` date neasteptate primite. Motiv: %2$s',
 	'EXCEPTION_ILLEGAL_CHARACTERS'	=> 'Campurile contin caractere nepermise.',
+
+	// Translators: do not change this
+	'EXCEPTION_WRONG_DATA_LANG'		=> $lang['WRONG_DATA_LANG'],
 ));

--- a/language/ru/exceptions.php
+++ b/language/ru/exceptions.php
@@ -55,4 +55,7 @@ $lang = array_merge($lang, array(
 	'EXCEPTION_NOT_UNIQUE'			=> 'Значение не уникально.',
 	'EXCEPTION_UNEXPECTED_VALUE'	=> 'Некорректное значение в поле `%1$s`. Причина: %2$s',
 	'EXCEPTION_ILLEGAL_CHARACTERS'	=> 'Введеная строка содержит некорректные символы.',
+
+	// Translators: do not change this
+	'EXCEPTION_WRONG_DATA_LANG'		=> $lang['WRONG_DATA_LANG'],
 ));

--- a/language/sk/exceptions.php
+++ b/language/sk/exceptions.php
@@ -55,4 +55,7 @@ $lang = array_merge($lang, array(
 	'EXCEPTION_NOT_UNIQUE'			=> 'Vstup nebol jedinečný.',
 	'EXCEPTION_UNEXPECTED_VALUE'	=> 'Pole `%1$s` obdržalo neočakávané dáta. Dôvod: %2$s',
 	'EXCEPTION_ILLEGAL_CHARACTERS'	=> 'Vstup obsahuje neplatné znaky.',
+
+	// Translators: do not change this
+	'EXCEPTION_WRONG_DATA_LANG'		=> $lang['WRONG_DATA_LANG'],
 ));

--- a/language/sv/exceptions.php
+++ b/language/sv/exceptions.php
@@ -56,4 +56,7 @@ $lang = array_merge($lang, array(
 	'EXCEPTION_NOT_UNIQUE'			=> 'Inmatningen var ej unik.',
 	'EXCEPTION_UNEXPECTED_VALUE'	=> 'Fältet `%1$s` har mottagit oväntad data. Orsak: %2$s',
 	'EXCEPTION_ILLEGAL_CHARACTERS'	=> 'Inmatningen innehöll otillåtna tecken.',
+
+	// Translators: do not change this
+	'EXCEPTION_WRONG_DATA_LANG'		=> $lang['WRONG_DATA_LANG'],
 ));

--- a/language/tr/exceptions.php
+++ b/language/tr/exceptions.php
@@ -55,4 +55,7 @@ $lang = array_merge($lang, array(
 	'EXCEPTION_NOT_UNIQUE'			=> 'Girdi eşsiz değil.',
 	'EXCEPTION_UNEXPECTED_VALUE'	=> '`%1$s` alanı beklenmeyen bir veri aldı. Sebep: %2$s',
 	'EXCEPTION_ILLEGAL_CHARACTERS'	=> 'Girdi uygun olmayan karakterler içeriyor.',
+
+	// Translators: do not change this
+	'EXCEPTION_WRONG_DATA_LANG'		=> $lang['WRONG_DATA_LANG'],
 ));

--- a/language/zh_cmn_hans/exceptions.php
+++ b/language/zh_cmn_hans/exceptions.php
@@ -56,4 +56,7 @@ $lang = array_merge($lang, array(
 	'EXCEPTION_NOT_UNIQUE'			=> '输入值不是唯一。',
 	'EXCEPTION_UNEXPECTED_VALUE'	=> '`%1$s` 字段收到无效数据。原因： %2$s',
 	'EXCEPTION_ILLEGAL_CHARACTERS'	=> '输入值含有非法字符。',
+
+	// Translators: do not change this
+	'EXCEPTION_WRONG_DATA_LANG'		=> $lang['WRONG_DATA_LANG'],
 ));

--- a/migrations/helper.php
+++ b/migrations/helper.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ *
+ * Board Rules extension for the phpBB Forum Software package.
+ *
+ * @copyright (c) 2017 phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ */
+
+namespace phpbb\boardrules\migrations;
+
+/**
+ * Migration helper
+ *
+ * This class contains methods that may be shared among
+ * board rules' migration classes.
+ *
+ * @package phpbb\boardrules\migrations
+ */
+class helper
+{
+	/**
+	 * @var \phpbb\db\driver\driver_interface
+	 */
+	protected $db;
+
+	/**
+	 * @var string The table prefix
+	 */
+	protected $table_prefix;
+
+	/**
+	 * Constructor
+	 *
+	 * @param \phpbb\db\driver\driver_interface $db
+	 * @param string                            $table_prefix
+	 */
+	public function __construct(\phpbb\db\driver\driver_interface $db, $table_prefix)
+	{
+		$this->db = $db;
+		$this->table_prefix = $table_prefix;
+	}
+
+	/**
+	 * Change rule_language values from lang_id to lang_iso
+	 *
+	 * @param string $new_column Name of the column to be updated
+	 * @param string $old_column Name of the column with old data
+	 */
+	public function change_rule_language($new_column, $old_column)
+	{
+		// Get installed language identifiers and iso codes
+		$sql = 'SELECT lang_id, lang_iso
+			FROM ' . LANG_TABLE;
+		$result = $this->db->sql_query($sql);
+		$rows = $this->db->sql_fetchrowset($result);
+		$this->db->sql_freeresult($result);
+
+		// Update the languages in the boardrules table, from id to iso
+		if (!empty($rows))
+		{
+			$this->db->sql_transaction('begin');
+
+			foreach ($rows as $row)
+			{
+				$sql = 'UPDATE ' . $this->table_prefix . "boardrules
+					SET $new_column = '" . $this->db->sql_escape($row['lang_iso']) . "'
+					WHERE $old_column = " . (int) $row['lang_id'];
+				$this->db->sql_query($sql);
+			}
+
+			$this->db->sql_transaction('commit');
+		}
+	}
+}

--- a/migrations/v20x/m15_language_iso.php
+++ b/migrations/v20x/m15_language_iso.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ *
+ * Board Rules extension for the phpBB Forum Software package.
+ *
+ * @copyright (c) 2017 phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ */
+
+namespace phpbb\boardrules\migrations\v20x;
+
+class m15_language_iso extends \phpbb\db\migration\container_aware_migration
+{
+	/**
+	 * @inheritDoc
+	 */
+	static public function depends_on()
+	{
+		return array(
+			'\phpbb\boardrules\migrations\v10x\m7_sample_rule_data',
+			'\phpbb\boardrules\migrations\v20x\m14_reparse',
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function update_schema()
+	{
+		return array(
+			'change_columns' => array(
+				$this->table_prefix . 'boardrules' => array(
+					'rule_language' => array('VCHAR:30', ''),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function revert_schema()
+	{
+		return array(
+			'change_columns' => array(
+				$this->table_prefix . 'boardrules' => array(
+					'rule_language' => array('UINT', ''),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function update_data()
+	{
+		return array(
+			array('custom', array(array($this, 'change_rule_language'))),
+		);
+	}
+
+	/**
+	 * Change rule_language values from lang_id to lang_iso
+	 */
+	public function change_rule_language()
+	{
+		// Get installed language identifiers and iso codes
+		$sql = 'SELECT lang_id, lang_iso
+			FROM ' . LANG_TABLE;
+		$result = $this->db->sql_query($sql);
+		$rows = $this->db->sql_fetchrowset($result);
+		$this->db->sql_freeresult($result);
+
+		// Update the languages in the boardrules table, from id to iso
+		if (!empty($rows))
+		{
+			$this->db->sql_transaction('begin');
+
+			foreach ($rows as $row)
+			{
+				$sql = 'UPDATE ' . $this->table_prefix . "boardrules
+					SET rule_language = '" . $this->db->sql_escape($row['lang_iso']) . "'
+					WHERE rule_language = " . (int) $row['lang_id'];
+				$this->db->sql_query($sql);
+			}
+
+			$this->db->sql_transaction('commit');
+		}
+	}
+}

--- a/migrations/v20x/m15_update_lang_schema.php
+++ b/migrations/v20x/m15_update_lang_schema.php
@@ -10,8 +10,18 @@
 
 namespace phpbb\boardrules\migrations\v20x;
 
-class m15_language_iso extends \phpbb\db\migration\container_aware_migration
+class m15_update_lang_schema extends \phpbb\db\migration\migration
 {
+	/**
+	 * @inheritDoc
+	 *
+	 * This migration is incompatible with PostgreSQL
+	 */
+	public function effectively_installed()
+	{
+		return $this->db->get_sql_layer() === 'postgres';
+	}
+
 	/**
 	 * @inheritDoc
 	 */
@@ -34,6 +44,11 @@ class m15_language_iso extends \phpbb\db\migration\container_aware_migration
 					'rule_language' => array('VCHAR:30', ''),
 				),
 			),
+			'add_index' => array(
+				$this->table_prefix . 'boardrules' => array(
+					'rule_language' => array('rule_language'),
+				),
+			),
 		);
 	}
 
@@ -43,9 +58,9 @@ class m15_language_iso extends \phpbb\db\migration\container_aware_migration
 	public function revert_schema()
 	{
 		return array(
-			'change_columns' => array(
+			'drop_keys' => array(
 				$this->table_prefix . 'boardrules' => array(
-					'rule_language' => array('UINT', ''),
+					'rule_language',
 				),
 			),
 		);

--- a/migrations/v20x/m15_update_lang_schema.php
+++ b/migrations/v20x/m15_update_lang_schema.php
@@ -81,27 +81,7 @@ class m15_update_lang_schema extends \phpbb\db\migration\migration
 	 */
 	public function change_rule_language()
 	{
-		// Get installed language identifiers and iso codes
-		$sql = 'SELECT lang_id, lang_iso
-			FROM ' . LANG_TABLE;
-		$result = $this->db->sql_query($sql);
-		$rows = $this->db->sql_fetchrowset($result);
-		$this->db->sql_freeresult($result);
-
-		// Update the languages in the boardrules table, from id to iso
-		if (!empty($rows))
-		{
-			$this->db->sql_transaction('begin');
-
-			foreach ($rows as $row)
-			{
-				$sql = 'UPDATE ' . $this->table_prefix . "boardrules
-					SET rule_language = '" . $this->db->sql_escape($row['lang_iso']) . "'
-					WHERE rule_language = " . (int) $row['lang_id'];
-				$this->db->sql_query($sql);
-			}
-
-			$this->db->sql_transaction('commit');
-		}
+		$helper = new \phpbb\boardrules\migrations\helper($this->db, $this->table_prefix);
+		$helper->change_rule_language('rule_language', 'rule_language');
 	}
 }

--- a/migrations/v20x/m16_update_lang_postgres.php
+++ b/migrations/v20x/m16_update_lang_postgres.php
@@ -85,7 +85,7 @@ class m16_update_lang_postgres extends \phpbb\db\migration\migration
 		}
 
 		// Add an index for the rule_language column
-		$this->db_tools->sql_create_index($boardrules_table, 'rule_language', 'rule_language');
+		$this->db_tools->sql_create_index($boardrules_table, 'rule_language', array('rule_language'));
 
 		// Get installed language identifiers and iso codes
 		$sql = 'SELECT lang_id, lang_iso

--- a/migrations/v20x/m16_update_lang_postgres.php
+++ b/migrations/v20x/m16_update_lang_postgres.php
@@ -87,28 +87,9 @@ class m16_update_lang_postgres extends \phpbb\db\migration\migration
 		// Add an index for the rule_language column
 		$this->db_tools->sql_create_index($boardrules_table, 'rule_language', array('rule_language'));
 
-		// Get installed language identifiers and iso codes
-		$sql = 'SELECT lang_id, lang_iso
-			FROM ' . LANG_TABLE;
-		$result = $this->db->sql_query($sql);
-		$rows = $this->db->sql_fetchrowset($result);
-		$this->db->sql_freeresult($result);
-
-		// Update the languages in the boardrules table, from id to iso
-		if (!empty($rows))
-		{
-			$this->db->sql_transaction('begin');
-
-			foreach ($rows as $row)
-			{
-				$sql = 'UPDATE ' . $boardrules_table . "
-					SET rule_language = '" . $this->db->sql_escape($row['lang_iso']) . "'
-					WHERE old_rule_language = " . (int) $row['lang_id'];
-				$this->db->sql_query($sql);
-			}
-
-			$this->db->sql_transaction('commit');
-		}
+		// Set the new rule_language values
+		$helper = new \phpbb\boardrules\migrations\helper($this->db, $this->table_prefix);
+		$helper->change_rule_language('rule_language', 'old_rule_language');
 
 		// Drop the temporary column
 		$this->db_tools->sql_column_remove($boardrules_table, 'old_rule_language');

--- a/migrations/v20x/m16_update_lang_postgres.php
+++ b/migrations/v20x/m16_update_lang_postgres.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ *
+ * Board Rules extension for the phpBB Forum Software package.
+ *
+ * @copyright (c) 2017 phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ */
+
+namespace phpbb\boardrules\migrations\v20x;
+
+class m16_update_lang_postgres extends \phpbb\db\migration\migration
+{
+	/**
+	 * @inheritDoc
+	 *
+	 * This migration is only for PostgreSQL
+	 */
+	public function effectively_installed()
+	{
+		return strpos($this->db->get_sql_layer(), 'postgres') === false;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	static public function depends_on()
+	{
+		return array(
+			'\phpbb\boardrules\migrations\v10x\m7_sample_rule_data',
+			'\phpbb\boardrules\migrations\v20x\m14_reparse',
+			'\phpbb\boardrules\migrations\v20x\m15_update_lang_schema',
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function update_data()
+	{
+		return array(
+			array('custom', array(array($this, 'alter_rule_language'))),
+		);
+	}
+
+	/**
+	 * Alter rule_language column for PostgreSQL
+	 *
+	 * PostgreSQL does not allow us to change a column's data type if it
+	 * already contains values, so the normal 'change_columns' action fails.
+	 * To work around this, we re-create a new rule_language column with
+	 * the new data type and copy the new data to it via specific queries.
+	 *
+	 * @throws \RuntimeException
+	 */
+	public function alter_rule_language()
+	{
+		// Ensure we are only processing this on postgresql dbms
+		if (strpos($this->db->get_sql_layer(), 'postgres') === false)
+		{
+			return;
+		}
+
+		$boardrules_table = $this->table_prefix . 'boardrules';
+
+		// Rename existing column to a temporary name
+		$sql = 'ALTER TABLE ' . $boardrules_table . ' 
+			RENAME COLUMN rule_language TO old_rule_language';
+		$this->db->sql_query($sql);
+
+		// Stop running if column rename failed (custom language must be hardcoded)
+		if (!$this->db_tools->sql_column_exists($boardrules_table , 'old_rule_language'))
+		{
+			throw new \RuntimeException('The column ‘rule_language’ could not be renamed.');
+		}
+
+		// Add a new rule_language column
+		$this->db_tools->sql_column_add($boardrules_table, 'rule_language', array('VCHAR:30', ''));
+
+		// Stop running if add column failed (custom language must be hardcoded)
+		if (!$this->db_tools->sql_column_exists($boardrules_table, 'rule_language'))
+		{
+			throw new \RuntimeException('The column ‘rule_language’ could not be created.');
+		}
+
+		// Add an index for the rule_language column
+		$this->db_tools->sql_create_index($boardrules_table, 'rule_language', 'rule_language');
+
+		// Get installed language identifiers and iso codes
+		$sql = 'SELECT lang_id, lang_iso
+			FROM ' . LANG_TABLE;
+		$result = $this->db->sql_query($sql);
+		$rows = $this->db->sql_fetchrowset($result);
+		$this->db->sql_freeresult($result);
+
+		// Update the languages in the boardrules table, from id to iso
+		if (!empty($rows))
+		{
+			$this->db->sql_transaction('begin');
+
+			foreach ($rows as $row)
+			{
+				$sql = 'UPDATE ' . $boardrules_table . "
+					SET rule_language = '" . $this->db->sql_escape($row['lang_iso']) . "'
+					WHERE old_rule_language = " . (int) $row['lang_id'];
+				$this->db->sql_query($sql);
+			}
+
+			$this->db->sql_transaction('commit');
+		}
+
+		// Drop the temporary column
+		$this->db_tools->sql_column_remove($boardrules_table, 'old_rule_language');
+	}
+}

--- a/operators/nestedset_rules.php
+++ b/operators/nestedset_rules.php
@@ -51,7 +51,7 @@ class nestedset_rules extends \phpbb\tree\nestedset
 	*/
 	public function use_language($language)
 	{
-		$this->sql_where = '%srule_language = ' . (int) $language;
+		$this->sql_where = "%srule_language = '" . $this->db->sql_escape($language) . "'";
 
 		return $this;
 	}

--- a/operators/rule.php
+++ b/operators/rule.php
@@ -43,12 +43,12 @@ class rule implements rule_interface
 	/**
 	* Get the rules
 	*
-	* @param int $language Language selection identifier; default: 0
+	* @param string $language Language selection iso
 	* @param int $parent_id Category to display rules from; default: 0
 	* @return array Array of rule data entities
 	* @access public
 	*/
-	public function get_rules($language = 0, $parent_id = 0)
+	public function get_rules($language, $parent_id = 0)
 	{
 		$entities = array();
 
@@ -72,13 +72,13 @@ class rule implements rule_interface
 	* Add a rule
 	*
 	* @param \phpbb\boardrules\entity\rule_interface $entity Rule entity with new data to insert
-	* @param int $language Language selection identifier; default: 0
+	* @param string $language Language selection iso
 	* @param int $parent_id Category to display rules from; default: 0
 	* @return \phpbb\boardrules\entity\rule_interface Added rule entity
 	* @access public
 	* @throws \phpbb\boardrules\exception\out_of_bounds
 	*/
-	public function add_rule($entity, $language = 0, $parent_id = 0)
+	public function add_rule($entity, $language, $parent_id = 0)
 	{
 		// Insert the rule data to the database for the given language selection
 		$entity->insert($language);
@@ -178,7 +178,7 @@ class rule implements rule_interface
 	/**
 	* Get a rule's parent rules (for use in breadcrumbs)
 	*
-	* @param int $language Language selection identifier
+	* @param string $language Language selection iso
 	* @param int $parent_id Category to display rules from
 	* @return array Array of rule data for a rule's parent rules
 	* @access public

--- a/operators/rule_interface.php
+++ b/operators/rule_interface.php
@@ -20,23 +20,23 @@ interface rule_interface
 	/**
 	* Get the rules
 	*
-	* @param int $language Language selection identifier; default: 0
+	* @param string $language Language selection iso
 	* @param int $parent_id Category to display rules from; default: 0
 	* @return array Array of rule data entities
 	* @access public
 	*/
-	public function get_rules($language = 0, $parent_id = 0);
+	public function get_rules($language, $parent_id = 0);
 
 	/**
 	* Add a rule
 	*
 	* @param \phpbb\boardrules\entity\rule_interface $entity Rule entity with new data to insert
-	* @param int $language Language selection identifier; default: 0
+	* @param string $language Language selection iso
 	* @param int $parent_id Category to display rules from; default: 0
 	* @return rule_interface Added rule entity
 	* @access public
 	*/
-	public function add_rule($entity, $language = 0, $parent_id = 0);
+	public function add_rule($entity, $language, $parent_id = 0);
 
 	/**
 	* Delete a rule
@@ -74,7 +74,7 @@ interface rule_interface
 	/**
 	* Get a rule's parent rules (for use in breadcrumbs)
 	*
-	* @param int $language Language selection identifier
+	* @param string $language Language selection iso
 	* @param int $parent_id Category to display rules from
 	* @return array Array of rule data for a rule's parent rules
 	* @access public

--- a/tests/controller/main_controller_test.php
+++ b/tests/controller/main_controller_test.php
@@ -38,7 +38,6 @@ class main_controller_test extends \phpbb_test_case
 		$lang_loader = new \phpbb\language\language_file_loader($phpbb_root_path, $phpEx);
 		$lang = new \phpbb\language\language($lang_loader);
 		$user = new \phpbb\user($lang, '\phpbb\datetime');
-		$user->data['lang_id'] = 1;
 
 		// Mock the rule operator and return an empty array for get_rules method
 		$rule_operator = $this->getMockBuilder('\phpbb\boardrules\operators\rule')

--- a/tests/entity/fixtures/rule.xml
+++ b/tests/entity/fixtures/rule.xml
@@ -70,4 +70,16 @@
 			<value>7</value>
 		</row>
 	</table>
+	<table name="phpbb_lang">
+		<column>lang_id</column>
+		<column>lang_iso</column>
+		<row>
+			<value>1</value>
+			<value>en</value>
+		</row>
+		<row>
+			<value>2</value>
+			<value>en-us</value>
+		</row>
+	</table>
 </dataset>

--- a/tests/entity/fixtures/rule.xml
+++ b/tests/entity/fixtures/rule.xml
@@ -15,7 +15,7 @@
 		<column>rule_message_bbcode_options</column>
 		<row>
 			<value>1</value>
-			<value>1</value>
+			<value>en</value>
 			<value>1</value>
 			<value>2</value>
 			<value>0</value>
@@ -29,7 +29,7 @@
 		</row>
 		<row>
 			<value>2</value>
-			<value>1</value>
+			<value>en</value>
 			<value>3</value>
 			<value>4</value>
 			<value>0</value>
@@ -43,7 +43,7 @@
 		</row>
 		<row>
 			<value>3</value>
-			<value>1</value>
+			<value>en</value>
 			<value>5</value>
 			<value>6</value>
 			<value>0</value>
@@ -57,7 +57,7 @@
 		</row>
 		<row>
 			<value>4</value>
-			<value>1</value>
+			<value>en</value>
 			<value>7</value>
 			<value>8</value>
 			<value>0</value>

--- a/tests/entity/fixtures/rule.xml
+++ b/tests/entity/fixtures/rule.xml
@@ -63,8 +63,8 @@
 			<value>0</value>
 			<value></value>
 			<value></value>
-			<value>title_3</value>
-			<value>message_3</value>
+			<value>title_4</value>
+			<value>message_4</value>
 			<value></value>
 			<value></value>
 			<value>7</value>

--- a/tests/entity/rule_entity_anchor_test.php
+++ b/tests/entity/rule_entity_anchor_test.php
@@ -138,15 +138,15 @@ class rule_entity_anchor_test extends rule_entity_base
 	{
 		return array(
 			// id // language // sent to set_anchor(), expected from get_anchor()
-			array(null, 1, '', ''), // new rule, anchor field empty, expect empty anchor to pass
-			array(null, 1, 'foo', 'foo'), // new rule, anchor is unique, expect unique anchor to pass
-			array(4, 1, '', ''), // existing rule, anchor is empty, expect empty anchor to pass
-			array(4, 1, 'foo', 'foo'), // existing rule, anchor is unique, expect unique anchor to pass
-			array(1, 1, 'anchor_1', 'anchor_1'), // existing rule, existing anchor is unique, expect existing anchor to pass
-			array(null, 2, 'anchor_1', 'anchor_1'), // new rule, new language, anchor is unique to the new language, expect anchor to pass
-			array(null, 0, '', ''), // new rule, no lang, anchor field empty, expect empty anchor to pass
-			array(null, 0, 'foo', 'foo'), // new rule, no lang, anchor is unique, expect unique anchor to pass
-			array(1, 0, 'anchor_1', 'anchor_1'), // existing rule, no lang, existing anchor is unique, expect existing anchor to pass
+			array(null, 'en', '', ''), // new rule, anchor field empty, expect empty anchor to pass
+			array(null, 'en', 'foo', 'foo'), // new rule, anchor is unique, expect unique anchor to pass
+			array(4, 'en', '', ''), // existing rule, anchor is empty, expect empty anchor to pass
+			array(4, 'en', 'foo', 'foo'), // existing rule, anchor is unique, expect unique anchor to pass
+			array(1, 'en', 'anchor_1', 'anchor_1'), // existing rule, existing anchor is unique, expect existing anchor to pass
+			array(null, 'en-us', 'anchor_1', 'anchor_1'), // new rule, new language, anchor is unique to the new language, expect anchor to pass
+			array(null, '', '', ''), // new rule, no lang, anchor field empty, expect empty anchor to pass
+			array(null, '', 'foo', 'foo'), // new rule, no lang, anchor is unique, expect unique anchor to pass
+			array(1, '', 'anchor_1', 'anchor_1'), // existing rule, no lang, existing anchor is unique, expect existing anchor to pass
 		);
 	}
 
@@ -187,10 +187,10 @@ class rule_entity_anchor_test extends rule_entity_base
 	{
 		return array(
 			// id // language // sent to set_anchor()
-			array(null, 1, 'anchor_1'), // new rule, new anchor is not unique (exists already in db)
-			array(1, 1, 'anchor_2'), // existing rule, new anchor is not unique (exists already in db)
-			array(null, 0, 'anchor_1'), // new rule, no lang, new anchor is not unique (exists already in db)
-			array(1, 0, 'anchor_2'), // existing rule, no lang, new anchor is not unique (exists already in db)
+			array(null, 'en', 'anchor_1'), // new rule, new anchor is not unique (exists already in db)
+			array(1, 'en', 'anchor_2'), // existing rule, new anchor is not unique (exists already in db)
+			array(null, '', 'anchor_1'), // new rule, no lang, new anchor is not unique (exists already in db)
+			array(1, '', 'anchor_2'), // existing rule, no lang, new anchor is not unique (exists already in db)
 		);
 	}
 

--- a/tests/entity/rule_entity_base.php
+++ b/tests/entity/rule_entity_base.php
@@ -65,7 +65,7 @@ class rule_entity_base extends \phpbb_database_test_case
 		return array(
 			1 => array(
 				'rule_id'							=> 1,
-				'rule_language'						=> 1,
+				'rule_language'						=> 'en',
 				'rule_left_id'						=> 0,
 				'rule_right_id'						=> 1,
 				'rule_parent_id'					=> 0,
@@ -79,7 +79,7 @@ class rule_entity_base extends \phpbb_database_test_case
 			),
 			2 => array(
 				'rule_id'							=> 2,
-				'rule_language'						=> 1,
+				'rule_language'						=> 'en',
 				'rule_left_id'						=> 2,
 				'rule_right_id'						=> 5,
 				'rule_parent_id'					=> 0,
@@ -93,7 +93,7 @@ class rule_entity_base extends \phpbb_database_test_case
 			),
 			3 => array(
 				'rule_id'							=> 3,
-				'rule_language'						=> 1,
+				'rule_language'						=> 'en',
 				'rule_left_id'						=> 3,
 				'rule_right_id'						=> 4,
 				'rule_parent_id'					=> 2,
@@ -107,7 +107,7 @@ class rule_entity_base extends \phpbb_database_test_case
 			),
 			4 => array(
 				'rule_id'							=> 4,
-				'rule_language'						=> 1,
+				'rule_language'						=> 'en',
 				'rule_left_id'						=> 6,
 				'rule_right_id'						=> 7,
 				'rule_parent_id'					=> 0,

--- a/tests/entity/rule_entity_import_test.php
+++ b/tests/entity/rule_entity_import_test.php
@@ -108,10 +108,10 @@ class rule_entity_import_test extends rule_entity_base
 			'rule_message_bbcode_options'	=> -1,
 		));
 
-		// Too long
-		$data[] = array_merge($import_data[1], array(
-			'rule_anchor'	=> str_repeat('a', 256),
-		));
+//		// Too long (no longer tested inside in the import method)
+//		$data[] = array_merge($import_data[1], array(
+//			'rule_anchor'	=> str_repeat('a', 256),
+//		));
 
 		// Too long
 		$data[] = array_merge($import_data[1], array(
@@ -127,6 +127,12 @@ class rule_entity_import_test extends rule_entity_base
 			unset($incomplete[$field]);
 
 			$data[] = $incomplete;
+		}
+
+		// Make each $data array a proper test array
+		foreach ($data as $key => $array)
+		{
+			$data[$key] = array($array);
 		}
 
 		return $data;

--- a/tests/entity/rule_entity_import_test.php
+++ b/tests/entity/rule_entity_import_test.php
@@ -85,11 +85,6 @@ class rule_entity_import_test extends rule_entity_base
 
 		// Out of range
 		$data[] = array_merge($import_data[1], array(
-			'rule_language'	=> -1,
-		));
-
-		// Out of range
-		$data[] = array_merge($import_data[1], array(
 			'rule_left_id'	=> -1,
 		));
 

--- a/tests/entity/rule_entity_insert_test.php
+++ b/tests/entity/rule_entity_insert_test.php
@@ -25,7 +25,7 @@ class rule_entity_insert_test extends rule_entity_base
 		$this->get_test_case_helpers()->set_s9e_services();
 
 		// Set a language variable
-		$language = 1;
+		$language = 'en';
 
 		// Setup the entity class
 		$entity = $this->get_rule_entity();
@@ -53,7 +53,7 @@ class rule_entity_insert_test extends rule_entity_base
 	public function test_insert_fails()
 	{
 		// Set a language variable
-		$language = 1;
+		$language = 'en';
 
 		// Load some import test data
 		$import_data = $this->get_import_data();

--- a/tests/entity/rule_entity_language_test.php
+++ b/tests/entity/rule_entity_language_test.php
@@ -80,6 +80,5 @@ class rule_entity_language_test extends rule_entity_base
 
 		// Assert that the anchor matches what's expected
 		$this->assertSame($language, $entity->get_language());
-
 	}
 }

--- a/tests/entity/rule_entity_language_test.php
+++ b/tests/entity/rule_entity_language_test.php
@@ -75,6 +75,12 @@ class rule_entity_language_test extends rule_entity_base
 		// Setup the entity class
 		$entity = $this->get_rule_entity();
 
+		// Assert that the anchor matches what's expected
+		if ($language !== 'en')
+		{
+			$this->setExpectedException('\phpbb\boardrules\exception\unexpected_value');
+		}
+
 		// Set the anchor
 		$entity->set_language($language);
 

--- a/tests/entity/rule_entity_language_test.php
+++ b/tests/entity/rule_entity_language_test.php
@@ -24,26 +24,26 @@ class rule_entity_language_test extends rule_entity_base
 	{
 		$import_data = $this->get_import_data();
 
-		// Set some data to test other than 1 from our import data
-		$import_data[3]['rule_language'] = 2;
-		$import_data[4]['rule_language'] = '7';
+		// Set some data to test other than en from our import data
+		$import_data[3]['rule_language'] = 'foo';
+		$import_data[4]['rule_language'] = 0;
 
 		return array(
 			array(
 				$import_data[1],
-				1,
+				'en',
 			),
 			array(
 				$import_data[2],
-				1,
+				'en',
 			),
 			array(
 				$import_data[3],
-				2,
+				'foo',
 			),
 			array(
 				$import_data[4],
-				7,
+				'0',
 			),
 		);
 	}

--- a/tests/entity/rule_entity_load_test.php
+++ b/tests/entity/rule_entity_load_test.php
@@ -28,7 +28,7 @@ class rule_entity_load_test extends rule_entity_base
 				1,
 				array(
 					'rule_id' => 1,
-					'rule_language' => 1,
+					'rule_language' => 'en',
 					'rule_left_id' => 1,
 					'rule_right_id' => 2,
 					'rule_parent_id' => 0,
@@ -41,7 +41,7 @@ class rule_entity_load_test extends rule_entity_base
 				2,
 				array(
 					'rule_id' => 2,
-					'rule_language' => 1,
+					'rule_language' => 'en',
 					'rule_left_id' => 3,
 					'rule_right_id' => 4,
 					'rule_parent_id' => 0,
@@ -54,7 +54,7 @@ class rule_entity_load_test extends rule_entity_base
 				3,
 				array(
 					'rule_id' => 3,
-					'rule_language' => 1,
+					'rule_language' => 'en',
 					'rule_left_id' => 5,
 					'rule_right_id' => 6,
 					'rule_parent_id' => 0,

--- a/tests/functional/admin_controller_test.php
+++ b/tests/functional/admin_controller_test.php
@@ -24,7 +24,7 @@ class admin_controller_test extends boardrules_functional_base
 		$this->admin_login();
 
 		// Load Pages ACP page
-		$crawler = self::request('GET', "adm/index.php?i=\\phpbb\\boardrules\\acp\\boardrules_module&mode=manage&language=1&sid={$this->sid}");
+		$crawler = self::request('GET', "adm/index.php?i=\\phpbb\\boardrules\\acp\\boardrules_module&mode=manage&language=en&sid={$this->sid}");
 
 		// Assert Board Rules module appears in sidebar
 		$this->assertContainsLang('ACP_BOARDRULES', $crawler->filter('.menu-block')->text());
@@ -73,7 +73,7 @@ class admin_controller_test extends boardrules_functional_base
 		$this->admin_login();
 
 		// Edit the rule identified by id 3
-		$crawler = self::request('GET', "adm/index.php?i=\\phpbb\\boardrules\\acp\\boardrules_module&mode=manage&language=1&action=edit&rule_id=3&sid={$this->sid}");
+		$crawler = self::request('GET', "adm/index.php?i=\\phpbb\\boardrules\\acp\\boardrules_module&mode=manage&language=en&action=edit&rule_id=3&sid={$this->sid}");
 
 		// Assert edit page is displayed
 		$this->assertContainsLang('ACP_BOARDRULES_EDIT_RULE', $crawler->filter('#main')->text());
@@ -89,7 +89,7 @@ class admin_controller_test extends boardrules_functional_base
 		$this->admin_login();
 
 		// Delete the rule identified by id 3
-		$crawler = self::request('GET', "adm/index.php?i=\\phpbb\\boardrules\\acp\\boardrules_module&mode=manage&language=1&action=delete&rule_id=3&sid={$this->sid}");
+		$crawler = self::request('GET', "adm/index.php?i=\\phpbb\\boardrules\\acp\\boardrules_module&mode=manage&language=en&action=delete&rule_id=3&sid={$this->sid}");
 
 		// Confirm delete
 		$form = $crawler->selectButton('confirm')->form();

--- a/tests/functional/version_check_test.php
+++ b/tests/functional/version_check_test.php
@@ -20,8 +20,6 @@ class version_check_test extends boardrules_functional_base
 	*/
 	public function test_version_check()
 	{
-		$this->markTestSkipped('The 1.0.x branch version check is not currently supported.');
-
 		// Log in to the ACP
 		$this->login();
 		$this->admin_login();

--- a/tests/operators/fixtures/rule.xml
+++ b/tests/operators/fixtures/rule.xml
@@ -15,7 +15,7 @@
 		<column>rule_message_bbcode_options</column>
 		<row>
 			<value>1</value>
-			<value>1</value>
+			<value>en</value>
 			<value>1</value>
 			<value>2</value>
 			<value>0</value>
@@ -29,7 +29,7 @@
 		</row>
 		<row>
 			<value>2</value>
-			<value>1</value>
+			<value>en</value>
 			<value>3</value>
 			<value>4</value>
 			<value>0</value>
@@ -43,7 +43,7 @@
 		</row>
 		<row>
 			<value>3</value>
-			<value>1</value>
+			<value>en</value>
 			<value>5</value>
 			<value>6</value>
 			<value>0</value>
@@ -57,7 +57,7 @@
 		</row>
 		<row>
 			<value>4</value>
-			<value>1</value>
+			<value>en</value>
 			<value>7</value>
 			<value>10</value>
 			<value>0</value>
@@ -71,7 +71,7 @@
 		</row>
 		<row>
 			<value>5</value>
-			<value>1</value>
+			<value>en</value>
 			<value>8</value>
 			<value>9</value>
 			<value>4</value>

--- a/tests/operators/rule_operator_add_rule_test.php
+++ b/tests/operators/rule_operator_add_rule_test.php
@@ -39,7 +39,8 @@ class rule_operator_add_rule_test extends rule_operator_base
 
 		// Set up some basic test variables
 		$test_id = 6;
-		$language = $parent_id = 1; // using 1 allows us to test the nestability
+		$language = 'en';
+		$parent_id = 1; // using 1 allows us to test the nestability
 
 		// Setup the operator class
 		$operator = $this->get_rule_operator();

--- a/tests/operators/rule_operator_get_rule_parents_test.php
+++ b/tests/operators/rule_operator_get_rule_parents_test.php
@@ -76,6 +76,9 @@ class rule_operator_get_rule_parents_test extends rule_operator_base
 		// Grab the rule data as an array of entities
 		$entities = $operator->get_rule_parents($language, $parent_id);
 
+		// Assert we have found some rules!
+		$this->assertNotEmpty($entities);
+
 		// Map the fields to the getters
 		$map = array(
 			'rule_id'		=> 'get_id',

--- a/tests/operators/rule_operator_get_rule_parents_test.php
+++ b/tests/operators/rule_operator_get_rule_parents_test.php
@@ -20,14 +20,14 @@ class rule_operator_get_rule_parents_test extends rule_operator_base
 	public function get_rule_parents_test_data()
 	{
 		return array(
-			// language id, rule id, expected data from the rule and its parents
+			// language iso, rule id, expected data from the rule and its parents
 			array(
-				1,
+				'en',
 				4,
 				array(
 					array(
 						'rule_id' => 4,
-						'rule_language' => 1,
+						'rule_language' => 'en',
 						'rule_left_id' => 7,
 						'rule_right_id' => 10,
 						'rule_parent_id' => 0,
@@ -37,12 +37,12 @@ class rule_operator_get_rule_parents_test extends rule_operator_base
 				),
 			),
 			array(
-				1,
+				'en',
 				5,
 				array(
 					array(
 						'rule_id' => 4,
-						'rule_language' => 1,
+						'rule_language' => 'en',
 						'rule_left_id' => 7,
 						'rule_right_id' => 10,
 						'rule_parent_id' => 0,
@@ -51,7 +51,7 @@ class rule_operator_get_rule_parents_test extends rule_operator_base
 					),
 					array(
 						'rule_id' => 5,
-						'rule_language' => 1,
+						'rule_language' => 'en',
 						'rule_left_id' => 8,
 						'rule_right_id' => 9,
 						'rule_parent_id' => 4,
@@ -114,8 +114,8 @@ class rule_operator_get_rule_parents_test extends rule_operator_base
 	{
 		return array(
 			// language, item_id, expected result (empty array)
-			array(0, 1, array()),
-			array(1, 0, array()),
+			array('foo', 1, array()), // wrong language, valid item
+			array('en', 0, array()), // valid language, wrong item
 		);
 	}
 

--- a/tests/operators/rule_operator_get_rules_test.php
+++ b/tests/operators/rule_operator_get_rules_test.php
@@ -22,11 +22,11 @@ class rule_operator_get_rules_test extends rule_operator_base
 		return array(
 			// language id to search, data which should match
 			array(
-				1,
+				'en',
 				array(
 					array(
 						'rule_id' => 1,
-						'rule_language' => 1,
+						'rule_language' => 'en',
 						'rule_left_id' => 1,
 						'rule_right_id' => 2,
 						'rule_parent_id' => 0,
@@ -35,7 +35,7 @@ class rule_operator_get_rules_test extends rule_operator_base
 					),
 					array(
 						'rule_id' => 2,
-						'rule_language' => 1,
+						'rule_language' => 'en',
 						'rule_left_id' => 3,
 						'rule_right_id' => 4,
 						'rule_parent_id' => 0,
@@ -44,7 +44,7 @@ class rule_operator_get_rules_test extends rule_operator_base
 					),
 					array(
 						'rule_id' => 3,
-						'rule_language' => 1,
+						'rule_language' => 'en',
 						'rule_left_id' => 5,
 						'rule_right_id' => 6,
 						'rule_parent_id' => 0,
@@ -53,7 +53,7 @@ class rule_operator_get_rules_test extends rule_operator_base
 					),
 					array(
 						'rule_id' => 4,
-						'rule_language' => 1,
+						'rule_language' => 'en',
 						'rule_left_id' => 7,
 						'rule_right_id' => 10,
 						'rule_parent_id' => 0,
@@ -62,7 +62,7 @@ class rule_operator_get_rules_test extends rule_operator_base
 					),
 					array(
 						'rule_id' => 5,
-						'rule_language' => 1,
+						'rule_language' => 'en',
 						'rule_left_id' => 8,
 						'rule_right_id' => 9,
 						'rule_parent_id' => 4,
@@ -125,8 +125,8 @@ class rule_operator_get_rules_test extends rule_operator_base
 	{
 		return array(
 			// language to search, expected result (empty array)
-			array(0, array()),
-			array(4, array()),
+			array('foo', array()),
+			array('bar', array()),
 		);
 	}
 

--- a/tests/operators/rule_operator_get_rules_test.php
+++ b/tests/operators/rule_operator_get_rules_test.php
@@ -87,6 +87,9 @@ class rule_operator_get_rules_test extends rule_operator_base
 		// Grab the rule data as an array of entities
 		$entities = $operator->get_rules($language);
 
+		// Assert we have found some rules!
+		$this->assertNotEmpty($entities);
+
 		// Map the fields to the getters
 		$map = array(
 			'rule_id'		=> 'get_id',


### PR DESCRIPTION
phpBB seems to use the language's ISO name more than the language's ID. If we switch to using ISO code names we can more easily handle language stuff, such as referencing a board's default lang from the config array. This will also prevent problems if a user deletes, then reinstalls a language pack, which could result in orphaning the rules written in that language (because the ID will change, but the ISO code will remain the same).